### PR TITLE
Dev/feature/enhance hover preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to the "timing" extension will be documented in this file.
 
 ## Unreleased - v1.1.0
-* **Added** setting `timing.hoverTargetFormat` that indicates the target format of the hover preview. Possible values are:
+* **Added** setting `timing.hoverTargetFormat` that indicates the target format of the hover preview ([#14](https://github.com/HaaLeo/vscode-timing/issues/14)). Possible values are:
   * `utc`: Show the hover preview in ISO 8601 UTC time. This is the default value.
   * `local`: Show the hover preview in ISO 8601 Local time.
   * `disable`: No hover preview is shown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to the "timing" extension will be documented in this file.
 
 ## Unreleased - v1.1.0
 * **Added** setting `timing.hoverTargetFormat` that indicates the target format of the hover preview. Possible values are:
-  * `UTC`: Show the hover preview in ISO 8601 UTC time. This is the default value.
-  * `Local`: Show the hover preview in ISO 8601 Local time.
-  * `Disable`: No hover preview is shown.
+  * `utc`: Show the hover preview in ISO 8601 UTC time. This is the default value.
+  * `local`: Show the hover preview in ISO 8601 Local time.
+  * `disable`: No hover preview is shown.
   * A custom [momentjs format](https://momentjs.com/docs/#/displaying/format/): For instance `LLLL`.
 
 ## 2018-09-06 - v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to the "timing" extension will be documented in this file.
 
+## Unreleased - v1.1.0
+* **Added** setting `timing.hoverTargetFormat` that indicates the target format of the hover preview. Possible values are:
+  * `UTC`: Show the hover preview in ISO 8601 UTC time. This is the default value.
+  * `Local`: Show the hover preview in ISO 8601 Local time.
+  * `Disable`: No hover preview is shown.
+  * A custom [momentjs format](https://momentjs.com/docs/#/displaying/format/): For instance `LLLL`.
+
 ## 2018-09-06 - v1.0.0
 * **BREAKING CHANGES**:
   * The extension now requires minimum VS Code version **1.26.0**

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Example:
 
 ### Hover Preview
 
-When you hover over a number the extension shows you the converted **UTC time** of that number and which **unit** was used for the conversion.
+When you hover over a number the extension shows you the converted **UTC**, **Local**, or **Custom** time and which **unit** was used for the conversion. The target time is indicated by the `timing.hoverTargetFormat` setting. Its default value is `UTC`.
 
 ![Hover Sample](doc/Hover_Sample.gif)
 
@@ -128,6 +128,11 @@ Alternatively, you can press the pencil button in the top right corner.
 * `timing.insertConvertedTime`: Indicates whether a converted time is inserted at the cursor's current position after conversion
 * `timing.ignoreFocusOut`: Indicates whether the input boxes remain visible when the focus is lost
 * `timing.hideResultViewOnEnter`: Indicates whether the result view is hidden when enter is pressed. When set to `false` the command will restart
+* `timing.hoverTargetFormat`: indicates the target format of the hover preview. Possible values are:
+  * `UTC`: Show the hover preview in ISO 8601 UTC time. This is the default value.
+  * `Local`: Show the hover preview in ISO 8601 Local time.
+  * `Disable`: No hover preview is shown.
+  * A custom [momentjs format](https://momentjs.com/docs/#/displaying/format/): For instance `LLLL`.
 
 ## Command Overview
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Example:
 
 ### Hover Preview
 
-When you hover over a number the extension shows you the converted **UTC**, **Local**, or **Custom** time and which **unit** was used for the conversion. The target time is indicated by the `timing.hoverTargetFormat` setting. Its default value is `UTC`.
+When you hover over a number the extension shows you the converted **UTC**, **Local**, or **Custom** time and which **unit** was used for the conversion. The target time is indicated by the `timing.hoverTargetFormat` setting. Its default value is `utc`.
 
 ![Hover Sample](doc/Hover_Sample.gif)
 
@@ -129,9 +129,9 @@ Alternatively, you can press the pencil button in the top right corner.
 * `timing.ignoreFocusOut`: Indicates whether the input boxes remain visible when the focus is lost
 * `timing.hideResultViewOnEnter`: Indicates whether the result view is hidden when enter is pressed. When set to `false` the command will restart
 * `timing.hoverTargetFormat`: indicates the target format of the hover preview. Possible values are:
-  * `UTC`: Show the hover preview in ISO 8601 UTC time. This is the default value.
-  * `Local`: Show the hover preview in ISO 8601 Local time.
-  * `Disable`: No hover preview is shown.
+  * `utc`: Show the hover preview in ISO 8601 UTC time. This is the default value.
+  * `local`: Show the hover preview in ISO 8601 Local time.
+  * `disable`: No hover preview is shown.
   * A custom [momentjs format](https://momentjs.com/docs/#/displaying/format/): For instance `LLLL`.
 
 ## Command Overview

--- a/package.json
+++ b/package.json
@@ -166,9 +166,9 @@
                 },
                 "timing.hoverTargetFormat": {
                     "title": "The target format of the hover preview.",
-                    "description": "Indicates the target format of the hover preview. It can be either \"UTC\", \"Local\", a custom format or \"Disable\" to disable the hover preview.",
+                    "description": "Indicates the target format of the hover preview. It can be either \"utc\", \"local\", a custom format or \"disable\" to disable the hover preview.",
                     "type": "string",
-                    "default": "UTC"
+                    "default": "utc"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "The timing configuration.",
+            "title": "Timing",
             "properties": {
                 "timing.customFormats": {
                     "title": "Custom time formats.",
@@ -159,10 +159,16 @@
                 },
                 "timing.hideResultViewOnEnter": {
                     "title": "Hide the result view when enter is pressed.",
-                    "description": "Indicates whether the result view is hidden when enter is pressed. When set to `false` the command will restart.",
+                    "description": "Indicates whether the result view is hidden when enter is pressed. When set to \"false\" the command will restart.",
                     "type": "boolean",
                     "default": true,
                     "pattern": "(true|false)"
+                },
+                "timing.hoverTargetFormat": {
+                    "title": "The target format of the hover preview.",
+                    "description": "Indicates the target format of the hover preview. It can be either \"UTC\", \"Local\", a custom format or \"Disable\" to disable the hover preview.",
+                    "type": "string",
+                    "default": "UTC"
                 }
             }
         }

--- a/src/test/mock/timeConverterMock.ts
+++ b/src/test/mock/timeConverterMock.ts
@@ -44,23 +44,5 @@ class TimeConverterMock implements TimeConverter {
         this.getNowAsIsoUtc.reset();
         this.getNowAsIsoLocal.reset();
     }
-
-    public restore() {
-        this.isoRfcToCustom.restore();
-        this.epochToCustom.restore();
-        this.customToIsoUtc.restore();
-        this.customToIsoLocal.restore();
-        this.epochToIsoUtc.restore();
-        this.epochToIsoLocal.restore();
-        this.isoRfcToEpoch.restore();
-        this.customToEpoch.restore();
-        this.isValidEpoch.restore();
-        this.isValidIsoRfc.restore();
-        this.isValidCustom.restore();
-        this.getNowAsCustom.restore();
-        this.getNowAsEpoch.restore();
-        this.getNowAsIsoUtc.restore();
-        this.getNowAsIsoLocal.restore();
-    }
 }
 export { TimeConverterMock };

--- a/src/test/utiltest/timeHoverProvider.test.ts
+++ b/src/test/utiltest/timeHoverProvider.test.ts
@@ -32,6 +32,8 @@ describe('TimeHoverProvider', () => {
             const file = await vscode.workspace.openTextDocument(uris[0]);
             testEditor = await vscode.window.showTextDocument(file);
         }
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('hoverTargetFormat', 'UTC');
     });
 
     beforeEach(() => {

--- a/src/test/utiltest/timeHoverProvider.test.ts
+++ b/src/test/utiltest/timeHoverProvider.test.ts
@@ -8,24 +8,20 @@
 'use strict';
 
 import * as assert from 'assert';
-import * as sinon from 'sinon';
+import { stub } from 'sinon';
 import * as vscode from 'vscode';
-import { TimeConverter } from '../../util/timeConverter';
 import { TimeHoverProvider } from '../../util/timeHoverProvider';
+import { TimeConverterMock } from '../mock/timeConverterMock';
 
 describe('TimeHoverProvider', () => {
 
     let testEditor: vscode.TextEditor;
     let testObject: TimeHoverProvider;
-    let timeConverter: TimeConverter;
+    let timeConverterMock: TimeConverterMock;
     let tokenSource: vscode.CancellationTokenSource;
-    let isValidEpochSpy: sinon.SinonSpy;
-    let epochToIsoUtcSpy: sinon.SinonSpy;
 
     before(async () => {
-        timeConverter = new TimeConverter();
-        isValidEpochSpy = sinon.spy(timeConverter, 'isValidEpoch');
-        epochToIsoUtcSpy = sinon.spy(timeConverter, 'epochToIsoUtc');
+        timeConverterMock = new TimeConverterMock();
 
         if (vscode.workspace.workspaceFolders !== undefined) {
             const uris = await vscode.workspace.findFiles('*.ts');
@@ -37,41 +33,108 @@ describe('TimeHoverProvider', () => {
     });
 
     beforeEach(() => {
-        isValidEpochSpy.resetHistory();
-        epochToIsoUtcSpy.resetHistory();
-        testObject = new TimeHoverProvider(timeConverter);
+        timeConverterMock.reset();
+        timeConverterMock.isValidEpoch.returns(true);
+        testObject = new TimeHoverProvider(timeConverterMock);
         tokenSource = new vscode.CancellationTokenSource();
     });
 
-    after(() => {
-        isValidEpochSpy.restore();
-        epochToIsoUtcSpy.restore();
-    });
-
-    it('should provide correct hover message.', async () => {
+    it('should provide correct utc hover message.', async () => {
+        timeConverterMock.epochToIsoUtc.returns('test-time');
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('hoverTargetFormat', 'utc');
 
         const result = await testObject.provideHover(
             testEditor.document,
             new vscode.Position(3, 32),
             tokenSource.token);
 
-        assert.equal(isValidEpochSpy.calledOnce, true);
-        assert.equal(epochToIsoUtcSpy.calledOnce, true);
-        assert.equal(epochToIsoUtcSpy.args[0][0], '123456789000');
+        assert.equal(timeConverterMock.isValidEpoch.calledOnce, true);
+        assert.equal(timeConverterMock.epochToIsoUtc.callCount, 1);
+        assert.equal(timeConverterMock.epochToIsoUtc.firstCall.args[0], '123456789000');
         assert.equal(result.contents.length, 1);
         assert.equal(
             result.contents[0],
-            '*Epoch Unit*: `s`  \n*UTC*: `1973-11-29T21:33:09.000Z`');
+            '*Epoch Unit*: `s`  \n*UTC*: `test-time`');
+    });
+
+    it('should provide correct local hover message.', async () => {
+        timeConverterMock.epochToIsoLocal.returns('test-time');
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('hoverTargetFormat', 'local');
+
+        const result = await testObject.provideHover(
+            testEditor.document,
+            new vscode.Position(3, 32),
+            tokenSource.token);
+
+        assert.equal(timeConverterMock.isValidEpoch.calledOnce, true);
+        assert.equal(timeConverterMock.epochToIsoLocal.calledOnce, true);
+        assert.equal(timeConverterMock.epochToIsoLocal.firstCall.args[0], '123456789000');
+        assert.equal(result.contents.length, 1);
+        assert.equal(
+            result.contents[0],
+            '*Epoch Unit*: `s`  \n*Local*: `test-time`');
+    });
+
+    it('should provide correct local hover message.', async () => {
+        timeConverterMock.epochToCustom.returns('test-time');
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('hoverTargetFormat', 'YYYY');
+
+        const result = await testObject.provideHover(
+            testEditor.document,
+            new vscode.Position(3, 32),
+            tokenSource.token);
+
+        assert.equal(timeConverterMock.isValidEpoch.calledOnce, true);
+        assert.equal(timeConverterMock.epochToCustom.calledOnce, true);
+        assert.equal(timeConverterMock.epochToCustom.firstCall.args[0], '123456789000');
+        assert.equal(timeConverterMock.epochToCustom.firstCall.args[1], 'YYYY');
+        assert.equal(result.contents.length, 1);
+        assert.equal(
+            result.contents[0],
+            '*Epoch Unit*: `s`  \n*Custom*: `test-time`');
     });
 
     it('should return undefined if position is no epoch time.', async () => {
+        timeConverterMock.isValidEpoch.callThrough();
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('hoverTargetFormat', 'utc');
+
         const result = await testObject.provideHover(
             testEditor.document,
             new vscode.Position(0, 0),
             tokenSource.token);
 
         assert.equal(result, undefined);
-        assert.equal(isValidEpochSpy.notCalled, true);
-        assert.equal(epochToIsoUtcSpy.notCalled, true);
+        assert.equal(timeConverterMock.isValidEpoch.notCalled, true);
     });
+
+    it('should return undefined if "disable" is set in the config.', async () => {
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('hoverTargetFormat', 'disable');
+
+        const result = await testObject.provideHover(
+            testEditor.document,
+            new vscode.Position(3, 32),
+            tokenSource.token);
+
+        assert.equal(result, undefined);
+        assert.equal(timeConverterMock.isValidEpoch.calledOnce, true);
+    });
+
+    it('should return undefined if config is empty.', async () => {
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('hoverTargetFormat', '');
+
+        const result = await testObject.provideHover(
+            testEditor.document,
+            new vscode.Position(3, 32),
+            tokenSource.token);
+
+        assert.equal(result, undefined);
+        assert.equal(timeConverterMock.isValidEpoch.calledOnce, true);
+    });
+
 });

--- a/src/test/utiltest/timeHoverProvider.test.ts
+++ b/src/test/utiltest/timeHoverProvider.test.ts
@@ -33,7 +33,7 @@ describe('TimeHoverProvider', () => {
             testEditor = await vscode.window.showTextDocument(file);
         }
         const config = vscode.workspace.getConfiguration('timing');
-        await config.update('hoverTargetFormat', 'UTC');
+        await config.update('hoverTargetFormat', 'utc');
     });
 
     beforeEach(() => {

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -47,6 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const toggleInsertConvertedTimeUserLevelCommand = new ToggleInsertConvertedTimeUserLevelCommand();
 
+    const timeHoverProvider = new TimeHoverProvider(timeConverter);
     /* tslint:disable:max-line-length */
 
     context.subscriptions.push(
@@ -66,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         vscode.commands.registerCommand('timing.toggleInsertConvertedTimeUserLevel', toggleInsertConvertedTimeUserLevelCommand.execute, toggleInsertConvertedTimeUserLevelCommand),
         // Register Hover Provider
-        vscode.languages.registerHoverProvider('*', new TimeHoverProvider(timeConverter))
+        timeHoverProvider, vscode.languages.registerHoverProvider('*', timeHoverProvider)
     );
     /* tslint:enable:max-line-length */
 }

--- a/src/util/timeHoverProvider.ts
+++ b/src/util/timeHoverProvider.ts
@@ -34,7 +34,7 @@ class TimeHoverProvider implements vscode.HoverProvider, vscode.Disposable {
         document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken):
         vscode.ProviderResult<vscode.Hover> {
         const timeRange = document.getWordRangeAtPosition(position, new RegExp('\\d+'));
-        let result: vscode.MarkdownString;
+        let result: vscode.Hover;
         if (timeRange !== undefined) {
             const hoveredWord = document.getText(timeRange);
             if (this._timeConverter.isValidEpoch(hoveredWord)) {
@@ -43,22 +43,22 @@ class TimeHoverProvider implements vscode.HoverProvider, vscode.Disposable {
 
                 if (this._hoverTargetFormat === 'UTC') {
                     const utc = this._timeConverter.epochToIsoUtc(input.inputAsMs.toString());
-                    result = new vscode.MarkdownString(prefix + '*UTC*: `' + utc + '`');
+                    result = new vscode.Hover(prefix + '*UTC*: `' + utc + '`');
                 } else if (this._hoverTargetFormat === 'Local') {
                     const local = this._timeConverter.epochToIsoLocal(input.inputAsMs.toString());
-                    result = new vscode.MarkdownString(prefix + '*Local*: `' + local + '`');
+                    result = new vscode.Hover(prefix + '*Local*: `' + local + '`');
                 } else if (this._hoverTargetFormat === 'Disable') {
                     result = undefined;
                 } else if (this._hoverTargetFormat) {
                     const custom = this._timeConverter.epochToCustom(
                         input.inputAsMs.toString(),
                         this._hoverTargetFormat);
-                    result = new vscode.MarkdownString(prefix + '*Custom*: `' + custom + '`');
+                    result = new vscode.Hover(prefix + '*Custom*: `' + custom + '`', timeRange);
                 }
             }
         }
 
-        return new vscode.Hover(result, timeRange);
+        return result;
     }
 
     public dispose(): void {

--- a/src/util/timeHoverProvider.ts
+++ b/src/util/timeHoverProvider.ts
@@ -11,31 +11,67 @@ import * as vscode from 'vscode';
 import { InputDefinition } from './inputDefinition';
 import { TimeConverter } from './timeConverter';
 
-class TimeHoverProvider implements vscode.HoverProvider {
+class TimeHoverProvider implements vscode.HoverProvider, vscode.Disposable {
 
     private _timeConverter: TimeConverter;
 
+    private _disposables: vscode.Disposable[];
+
+    private _hoverTargetFormat: string;
+
     constructor(timeConverter: TimeConverter) {
         this._timeConverter = timeConverter;
+
+        this.updateHoverTargetFormat();
+        vscode.workspace.onDidChangeConfiguration((changedEvent) => {
+            if (changedEvent.affectsConfiguration('timing.hoverTargetFormat')) {
+                this.updateHoverTargetFormat();
+            }
+        }, this, this._disposables);
     }
 
     public provideHover(
         document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken):
         vscode.ProviderResult<vscode.Hover> {
         const timeRange = document.getWordRangeAtPosition(position, new RegExp('\\d+'));
-        let result: vscode.Hover;
+        let result: vscode.MarkdownString;
         if (timeRange !== undefined) {
             const hoveredWord = document.getText(timeRange);
             if (this._timeConverter.isValidEpoch(hoveredWord)) {
                 const input = new InputDefinition(hoveredWord);
-                const utc = this._timeConverter.epochToIsoUtc(input.inputAsMs.toString());
-                result = new vscode.Hover(
-                    '*Epoch Unit*: `' + input.originalUnit + '`  \n*UTC*: `' + utc + '`',
-                    timeRange);
+                const prefix = '*Epoch Unit*: `' + input.originalUnit + '`  \n';
+
+                if (this._hoverTargetFormat === 'UTC') {
+                    const utc = this._timeConverter.epochToIsoUtc(input.inputAsMs.toString());
+                    result = new vscode.MarkdownString(prefix + '*UTC*: `' + utc + '`');
+                } else if (this._hoverTargetFormat === 'Local') {
+                    const local = this._timeConverter.epochToIsoLocal(input.inputAsMs.toString());
+                    result = new vscode.MarkdownString(prefix + '*Local*: `' + local + '`');
+                } else if (this._hoverTargetFormat === 'Disable') {
+                    result = undefined;
+                } else if (this._hoverTargetFormat) {
+                    const custom = this._timeConverter.epochToCustom(
+                        input.inputAsMs.toString(),
+                        this._hoverTargetFormat);
+                    result = new vscode.MarkdownString(prefix + '*Custom*: `' + custom + '`');
+                }
             }
         }
 
-        return result;
+        return new vscode.Hover(result, timeRange);
+    }
+
+    public dispose(): void {
+        this._disposables.forEach((disposable) => disposable.dispose());
+    }
+
+    private updateHoverTargetFormat(): void {
+        const config = vscode.workspace.getConfiguration('timing')
+            .get('hoverTargetFormat', 'UTC');
+
+        if (typeof (config) === 'string') {
+            this._hoverTargetFormat = config;
+        }
     }
 }
 

--- a/src/util/timeHoverProvider.ts
+++ b/src/util/timeHoverProvider.ts
@@ -41,19 +41,21 @@ class TimeHoverProvider implements vscode.HoverProvider, vscode.Disposable {
                 const input = new InputDefinition(hoveredWord);
                 const prefix = '*Epoch Unit*: `' + input.originalUnit + '`  \n';
 
-                if (this._hoverTargetFormat === 'UTC') {
+                if (this._hoverTargetFormat === 'utc') {
                     const utc = this._timeConverter.epochToIsoUtc(input.inputAsMs.toString());
                     result = new vscode.Hover(prefix + '*UTC*: `' + utc + '`');
-                } else if (this._hoverTargetFormat === 'Local') {
+                } else if (this._hoverTargetFormat === 'local') {
                     const local = this._timeConverter.epochToIsoLocal(input.inputAsMs.toString());
                     result = new vscode.Hover(prefix + '*Local*: `' + local + '`');
-                } else if (this._hoverTargetFormat === 'Disable') {
+                } else if (this._hoverTargetFormat === 'disable') {
                     result = undefined;
                 } else if (this._hoverTargetFormat) {
                     const custom = this._timeConverter.epochToCustom(
                         input.inputAsMs.toString(),
                         this._hoverTargetFormat);
                     result = new vscode.Hover(prefix + '*Custom*: `' + custom + '`', timeRange);
+                } else {
+                    result = undefined;
                 }
             }
         }
@@ -67,7 +69,7 @@ class TimeHoverProvider implements vscode.HoverProvider, vscode.Disposable {
 
     private updateHoverTargetFormat(): void {
         const config = vscode.workspace.getConfiguration('timing')
-            .get('hoverTargetFormat', 'UTC');
+            .get('hoverTargetFormat', 'utc');
 
         if (typeof (config) === 'string') {
             this._hoverTargetFormat = config;


### PR DESCRIPTION
Fixes #14:
**Added** setting `timing.hoverTargetFormat` that indicates the target format of the hover preview.  
Possible values are:
  * `utc`: Show the hover preview in ISO 8601 UTC time. This is the default value.
  * `local`: Show the hover preview in ISO 8601 Local time.
  * `disable`: No hover preview is shown.
  * A custom [momentjs format](https://momentjs.com/docs/#/displaying/format/): For instance `LLLL`.
