### PR TITLE
Add "to GPS" conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Command Id | Description | Optional Arguments (`string`)
 `timing.epochToIsoTimezone`| Epoch ⟶ ISO 8601 Custom Timezone | `timezone`
 `timing.epochToIsoUtc`| Epoch ⟶ ISO 8601 UTC
 `timing.epochToReadableDuration`| Epoch ⟶ Readable Duration | `sourceUnit`
+`timing.epochToGps`| Epoch ⟶ GPS
 `timing.isoDurationToEpoch`| ISO 8601 Duration ⟶ Epoch | `targetUnit`
 `timing.isoRfcToCustom`| ISO 8601 / RFC 2822 ⟶ Custom | `targetFormat`
 `timing.isoRfcToEpoch`| ISO 8601 / RFC 2822 ⟶ Epoch | `targetUnit`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,6 +2145,11 @@
                 }
             }
         },
+        "gps-time": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/gps-time/-/gps-time-1.0.7.tgz",
+            "integrity": "sha512-FJwuU5Y4zOIyHUEXKXe7rJrfAgK7mBiGQZP1ijYfA/VXQ+yIa9PT6FGR+JUQyi53Ltbxnl8Xz4/OO4SZdbeTFA=="
+        },
         "graceful-fs": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "webpack-cli": "^4.7.0"
     },
     "dependencies": {
+        "gps-time": "^1.0.7",
         "moment-timezone": "^0.5.33",
         "tz-ids": "^1.0.0"
     },
@@ -130,6 +131,11 @@
                 "command": "timing.epochToIsoDuration",
                 "category": "Timing",
                 "title": "Epoch ⟶ ISO 8601 Duration"
+            },
+            {
+                "command": "timing.epochToGps",
+                "category": "Timing",
+                "title": "Epoch ⟶ Gps"
             },
             {
                 "command": "timing.isoDurationToEpoch",
@@ -221,6 +227,10 @@
                 {
                     "command": "timing.epochToIsoDuration",
                     "when": "timing:epochToIsoDuration:enabled"
+                },
+                {
+                    "command": "timing.epochToGps",
+                    "when": "timing:epochToGps:enabled"
                 },
                 {
                     "command": "timing.isoDurationToEpoch",
@@ -488,6 +498,7 @@
                                     "timing.epochToIsoLocal",
                                     "timing.epochToIsoUtc",
                                     "timing.epochToIsoTimezone",
+                                    "timing.epochToGps",
                                     "timing.isoDurationToEpoch",
                                     "timing.isoRfcToCustom",
                                     "timing.isoRfcToEpoch",

--- a/src/commands/epochToGpsCommand.ts
+++ b/src/commands/epochToGpsCommand.ts
@@ -1,0 +1,75 @@
+/*!
+ * ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Leo Hanisch. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+ * --------------------------------------------------------------------------------------------
+ */
+
+'use strict';
+
+import { InputDefinition } from '../util/inputDefinition';
+
+import { InputBoxStep } from '../step/inputBoxStep';
+import { MultiStepHandler } from '../step/multiStepHandler';
+import { StepResult } from '../step/stepResult';
+import { InputFlowAction } from '../util/inputFlowAction';
+import { CommandBase } from './commandBase';
+
+/**
+ * Command to convert epoch time to GPS time.
+ */
+class EpochToGpsCommand extends CommandBase {
+
+    private readonly title: string = 'Epoch → GPS';
+
+    /**
+     * Execute the command.
+     */
+    public async execute(): Promise<void> {
+        let loopResult: StepResult = new StepResult(InputFlowAction.Continue, await this.getPreInput());
+        if (!this._stepHandler) {
+            this.initialize();
+        }
+
+        do {
+            let rawInput = loopResult.value;
+
+            const internalResult = await this.internalExecute(loopResult.action, 'epochToGps', rawInput);
+
+            [rawInput] = internalResult.stepHandlerResult;
+            const input = new InputDefinition(rawInput);
+
+            if (internalResult.showResultBox) {
+                loopResult = await this._resultBox.show(
+                    'Input: ' + input.originalInput + ' (' + input.originalUnit + ')',
+                    this.title + ': Result',
+                    internalResult.conversionResult,
+                    this.insert,
+                    this._ignoreFocusOut);
+            } else {
+                loopResult = new StepResult(InputFlowAction.Cancel, undefined);
+            }
+
+        } while (loopResult.action === InputFlowAction.Back
+            || (!this._hideResultViewOnEnter && loopResult.action === InputFlowAction.Continue));
+    }
+
+    /**
+     * Initialize all members.
+     */
+    private initialize(): void {
+        const getEpochTimeStep = new InputBoxStep(
+            '123456789',
+            'Insert the epoch time.',
+            this.title,
+            'Ensure the epoch time is valid.',
+            this._timeConverter.isValidEpoch,
+            true);
+
+        this._stepHandler = new MultiStepHandler();
+        this._stepHandler.registerStep(getEpochTimeStep, 0);
+        this._disposables.push(this._stepHandler);
+    }
+}
+
+export { EpochToGpsCommand };

--- a/src/test/commandstest/epochToGpsCommand.test.ts
+++ b/src/test/commandstest/epochToGpsCommand.test.ts
@@ -1,0 +1,100 @@
+/*!
+ * ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Leo Hanisch. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+ * --------------------------------------------------------------------------------------------
+ */
+
+'use strict';
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { EpochToGpsCommand } from '../../commands/epochToGpsCommand';
+import { StepResult } from '../../step/stepResult';
+import { ConfigHelper } from '../../util/configHelper';
+import { InputFlowAction } from '../../util/inputFlowAction';
+import { ResultBox } from '../../util/resultBox';
+import { TimeConverter } from '../../util/timeConverter';
+import { ExtensionContextMock } from '../mock/extensionContextMock';
+import { MultiStepHandlerMock } from '../mock/multiStepHandlerMock';
+
+describe('EpochToGpsCommand', () => {
+    let timeConverter: TimeConverter;
+    let testObject: EpochToGpsCommand;
+    let testEditor: vscode.TextEditor;
+    let handlerMock: MultiStepHandlerMock;
+    let showResultStub: sinon.SinonStub;
+
+    before(async () => {
+        handlerMock = new MultiStepHandlerMock();
+        timeConverter = new TimeConverter();
+        showResultStub = sinon.stub(ResultBox.prototype, 'show');
+
+        if (vscode.workspace.workspaceFolders !== undefined) {
+            const uris = await vscode.workspace.findFiles('*.ts');
+            const file = await vscode.workspace.openTextDocument(uris[0]);
+            testEditor = await vscode.window.showTextDocument(file);
+        }
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('customFormats', []);
+    });
+
+    after(async () => {
+        const config = vscode.workspace.getConfiguration('timing');
+        await config.update('customFormats', undefined);
+        await config.update('insertConvertedTime', undefined);
+        await config.update('ignoreFocusOut', undefined);
+        await config.update('hideResultViewOnEnter', undefined);
+        showResultStub.restore();
+        handlerMock.restore();
+    });
+
+    describe('execute', () => {
+
+        beforeEach('Reset', () => {
+            testObject = new EpochToGpsCommand(new ExtensionContextMock(), timeConverter, new ConfigHelper());
+            testEditor.selection = new vscode.Selection(new vscode.Position(3, 32), new vscode.Position(3, 41));
+            handlerMock.run.returns(new Promise(resolve => resolve(['1000'])));
+            showResultStub.returns(new StepResult(InputFlowAction.Cancel, undefined));
+        });
+
+        afterEach(() => {
+            handlerMock.reset();
+            showResultStub.resetHistory();
+        });
+
+        it('Should stop if user canceled during epoch time insertion', async () => {
+            testEditor.selection = new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, 0));
+            handlerMock.run.returns(new Promise(resolve => resolve([])));
+
+            await testObject.execute();
+
+            assert.strictEqual(handlerMock.run.calledOnce, true);
+            assert.strictEqual(handlerMock.registerStep.calledOnce, true);
+            assert.strictEqual(showResultStub.notCalled, true);
+        });
+
+        it('Should show result after calculation', async () => {
+            await testObject.execute();
+
+            assert.strictEqual(handlerMock.run.calledOnce, true);
+            assert.strictEqual(handlerMock.registerStep.calledOnce, true);
+            assert.strictEqual(showResultStub.calledOnce, true);
+            assert.strictEqual(
+                showResultStub.args[0][2],
+                timeConverter.epochToGps('1000'));
+        });
+
+        it('Should start with last step if input flow action is Back.', async () => {
+            showResultStub.onFirstCall().returns(new StepResult(InputFlowAction.Back, undefined));
+            showResultStub.onSecondCall().returns(new StepResult(InputFlowAction.Cancel, undefined));
+
+            await testObject.execute();
+
+            assert.strictEqual(handlerMock.run.calledTwice, true);
+            assert.strictEqual(handlerMock.run.secondCall.args[2], -1);
+            showResultStub.resetBehavior();
+        });
+    });
+});

--- a/src/test/mock/timeConverterMock.ts
+++ b/src/test/mock/timeConverterMock.ts
@@ -24,6 +24,7 @@ class TimeConverterMock implements TimeConverter {
     public customToISOLocal = sinon.stub();
     public epochToISOUtc = sinon.stub();
     public epochToIsoLocal = sinon.stub();
+    public epochToGps = sinon.stub();
     public isoRfcToEpoch = sinon.stub();
     public customToEpoch = sinon.stub();
     public isValidEpoch = sinon.stub();
@@ -46,6 +47,7 @@ class TimeConverterMock implements TimeConverter {
         this.customToISOLocal.reset();
         this.epochToISOUtc.reset();
         this.epochToIsoLocal.reset();
+        this.epochToGps.reset();
         this.isoRfcToEpoch.reset();
         this.customToEpoch.reset();
         this.isValidEpoch.reset();

--- a/src/test/utiltest/configHelper.test.ts
+++ b/src/test/utiltest/configHelper.test.ts
@@ -36,6 +36,7 @@ describe('ConfigHelper', () => {
             'timing:epochToIsoLocal:enabled': true,
             'timing:epochToIsoUtc:enabled': true,
             'timing:epochToIsoTimezone:enabled': true,
+            'timing:epochToGps:enabled': true,
             'timing:isoDurationToEpoch:enabled': true,
             'timing:isoRfcToCustom:enabled': true,
             'timing:isoRfcToEpoch:enabled': true,
@@ -71,9 +72,9 @@ describe('ConfigHelper', () => {
         });
 
         it('Set context keys', () => {
-            const args = executeCommandSpy.args.slice(executeCommandSpy.args.length - 19);
+            const args = executeCommandSpy.args.slice(executeCommandSpy.args.length - 20);
 
-            assert.strictEqual(args.length, 19);
+            assert.strictEqual(args.length, 20);
             Object.entries(expectedHiddenCommands).forEach(([key, isEnabled], index) => {
                 assert.strictEqual(args[index][0], 'setContext');
                 assert.strictEqual(args[index][1], key);
@@ -87,9 +88,9 @@ describe('ConfigHelper', () => {
             expectedHiddenCommands['timing:customToCustom:enabled'] = false;
             expectedHiddenCommands['timing:customToIsoLocal:enabled'] = false;
 
-            // Get last 19 calls
-            const args = executeCommandSpy.args.slice(executeCommandSpy.args.length - 19);
-            assert.strictEqual(args.length, 19);
+            // Get last 20 calls
+            const args = executeCommandSpy.args.slice(executeCommandSpy.args.length - 20);
+            assert.strictEqual(args.length, 20);
 
             Object.entries(expectedHiddenCommands).forEach(([key, isEnabled], index) => {
                 assert.strictEqual(args[index][0], 'setContext');
@@ -104,8 +105,8 @@ describe('ConfigHelper', () => {
             expectedHiddenCommands['timing:customToCustom:enabled'] = false;
             expectedHiddenCommands['timing:customToIsoLocal:enabled'] = false;
 
-            const args = executeCommandSpy.args.slice(executeCommandSpy.args.length - 19);
-            assert.strictEqual(args.length, 19);
+            const args = executeCommandSpy.args.slice(executeCommandSpy.args.length - 20);
+            assert.strictEqual(args.length, 20);
 
             Object.entries(expectedHiddenCommands).forEach(([key, isEnabled], index) => {
                 assert.strictEqual(args[index][0], 'setContext');

--- a/src/test/utiltest/timeConverter.test.ts
+++ b/src/test/utiltest/timeConverter.test.ts
@@ -65,6 +65,13 @@ describe('TimeConverter', () => {
         });
     });
 
+    describe('epochToGps', () => {
+        it('Should convert to GPS correctly.', () => {
+            const result = testObject.epochToGps('123456789000');
+            assert.strictEqual(result, ('-192508011000'));
+        });
+    });
+
     describe('isoDurationToEpoch', () => {
         it('Should convert to epoch correctly as s.', () => {
             const result = testObject.isoDurationToEpoch('P1Y2M3DT4H5M6S', 's');

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -16,6 +16,7 @@ import { CustomToEpochCommand } from './commands/customToEpochCommand';
 import { CustomToIsoLocalCommand } from './commands/customToIsoLocalCommand';
 import { CustomToIsoUtcCommand } from './commands/customToIsoUtcCommand';
 import { EpochToCustomCommand } from './commands/epochToCustomCommand';
+import { EpochToGpsCommand } from './commands/epochToGpsCommand';
 import { EpochToISODurationCommand } from './commands/epochToISODurationCommand';
 import { EpochToIsoLocalCommand } from './commands/epochToIsoLocalCommand';
 import { EpochToIsoTimezoneCommand } from './commands/epochToIsoTimezoneCommand';
@@ -56,6 +57,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const epochToIsoLocalCommand = new EpochToIsoLocalCommand(context, timeConverter, configHelper);
     const epochToIsoUtcCommand = new EpochToIsoUtcCommand(context, timeConverter, configHelper);
     const epochToIsoTimezoneCommand = new EpochToIsoTimezoneCommand(context, timeConverter, configHelper);
+    const epochToGpsCommand = new EpochToGpsCommand(context, timeConverter, configHelper);
     const nowAsEpochCommand = new NowAsEpochCommand(context, timeConverter, configHelper);
     const nowAsCustomCommand = new NowAsCustomCommand(context, timeConverter, configHelper);
     const nowAsIsoLocalCommand = new NowAsIsoLocalCommand(context, timeConverter, configHelper);
@@ -84,6 +86,7 @@ export function activate(context: vscode.ExtensionContext): void {
         epochToIsoLocalCommand, vscode.commands.registerCommand('timing.epochToIsoLocal', epochToIsoLocalCommand.execute, epochToIsoLocalCommand),
         epochToIsoUtcCommand, vscode.commands.registerCommand('timing.epochToIsoTimezone', epochToIsoTimezoneCommand.execute, epochToIsoTimezoneCommand),
         epochToIsoUtcCommand, vscode.commands.registerCommand('timing.epochToIsoUtc', epochToIsoUtcCommand.execute, epochToIsoUtcCommand),
+        epochToGpsCommand, vscode.commands.registerCommand('timing.epochToGps', epochToGpsCommand.execute, epochToGpsCommand),
         isoDurationToEpochCommand, vscode.commands.registerCommand('timing.isoDurationToEpoch', isoDurationToEpochCommand.execute, isoDurationToEpochCommand),
         isoRfcToCustomCommand, vscode.commands.registerCommand('timing.isoRfcToCustom', isoRfcToCustomCommand.execute, isoRfcToCustomCommand),
         isoRfcToEpochCommand, vscode.commands.registerCommand('timing.isoRfcToEpoch', isoRfcToEpochCommand.execute, isoRfcToEpochCommand),

--- a/src/util/configHelper.ts
+++ b/src/util/configHelper.ts
@@ -61,6 +61,7 @@ class ConfigHelper implements vscode.Disposable {
             'timing.epochToIsoLocal',
             'timing.epochToIsoUtc',
             'timing.epochToIsoTimezone',
+            'timing.epochToGps',
             'timing.isoDurationToEpoch',
             'timing.isoRfcToCustom',
             'timing.isoRfcToEpoch',

--- a/src/util/timeConverter.ts
+++ b/src/util/timeConverter.ts
@@ -10,6 +10,7 @@
 import * as moment from 'moment-timezone';
 import { Constants } from '../util/constants';
 import { InputDefinition } from './inputDefinition';
+import * as gpsTime from 'gps-time';
 
 class TimeConverter {
     public isoRfcToCustom(date: string, targetFormat: string): string {
@@ -111,6 +112,29 @@ class TimeConverter {
         const ms = new InputDefinition(epoch).inputAsMs;
         const result = moment(ms, 'x').toISOString(true);
         return result;
+    }
+
+    public epochToGps(epoch: string): string {
+        const def = new InputDefinition(epoch)
+        const ms = def.inputAsMs;
+        let result: number;
+        switch (def.originalUnit) {
+            case Constants.SECONDS:
+                result = gpsTime.toGPSMS(ms) / 1000;
+                break;
+            case Constants.MILLISECONDS:
+                result = gpsTime.toGPSMS(ms);
+                break;
+            case Constants.MICROSECONDS:
+                result = gpsTime.toGPSMS(ms) * 1000;
+                break;
+            case Constants.NANOSECONDS:
+                result = gpsTime.toGPSMS(ms) * 1000000;
+                break;
+            default:
+                throw new Error('Unknown option="' + def.originalUnit + '" detected.');
+        }
+        return result.toString();
     }
 
     public isoDurationToEpoch(duration: string, targetUnit: string): string {


### PR DESCRIPTION
This PR adds a new command to convert a Unix epoch time to a GPS time (number of seconds from GPS epoch on January 6 1980). It uses the [gps-time](https://www.npmjs.com/package/gps-time) library that takes the leap seconds into account.